### PR TITLE
Feature: Enforce response codes

### DIFF
--- a/src/BeSimple/SoapClient/Tests/WsdlDownloaderTest.php
+++ b/src/BeSimple/SoapClient/Tests/WsdlDownloaderTest.php
@@ -271,6 +271,26 @@ class WsdlDownloaderTest extends AbstractWebserverTest
         $this->assertEquals('http://localhost/test', $m->invoke($wsdlDownloader, 'http://localhost/sub/sub/sub/', '../../../test'));
     }
 
+    /**
+     * Test that only HTTP 200 is the accepted response and everything else should throw an exception.
+     *
+     * @throws \ErrorException
+     */
+    public function testInvalidResponseCodes()
+    {
+        $this->expectException('ErrorException');
+        $this->expectExceptionMessage('SOAP-ERROR: Parsing WSDL: Unexpected response code received from \'http://somefake.url/wsdl\', response code: 302');
+
+        $curlMock = $this->createMock('BeSimple\SoapClient\Curl');
+        $curlMock->expects($this->any())
+            ->method('getResponseStatusCode')
+            ->willReturn(302);
+
+        $wsdlDownloader = new WsdlDownloader($curlMock);
+
+        $wsdlDownloader->download('http://somefake.url/wsdl');
+    }
+
     public static function setUpBeforeClass()
     {
         parent::setUpBeforeClass();

--- a/src/BeSimple/SoapClient/WsdlDownloader.php
+++ b/src/BeSimple/SoapClient/WsdlDownloader.php
@@ -14,6 +14,7 @@ namespace BeSimple\SoapClient;
 
 use BeSimple\SoapCommon\Cache;
 use BeSimple\SoapCommon\Helper;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Downloads WSDL files with cURL. Uses the WSDL_CACHE_* constants and the
@@ -26,11 +27,6 @@ use BeSimple\SoapCommon\Helper;
 class WsdlDownloader
 {
     const XML_MIN_LENGTH = 25;
-
-    /**
-     *  Expected HTTP status code when downloading wsdls.
-     */
-    const HTTP_OK = 200;
 
     /**
      * Cache enabled.
@@ -105,7 +101,7 @@ class WsdlDownloader
                     // execute request
                     $this->curl->exec($wsdl);
                     // get content
-                    if (static::HTTP_OK === $this->curl->getResponseStatusCode()) {
+                    if (Response::HTTP_OK === $this->curl->getResponseStatusCode()) {
                         $response = $this->curl->getResponseBody();
                         if (empty($response)) {
                             throw new \ErrorException("SOAP-ERROR: Parsing WSDL: Got empty wsdl from '" . $wsdl ."'");

--- a/src/BeSimple/SoapClient/WsdlDownloader.php
+++ b/src/BeSimple/SoapClient/WsdlDownloader.php
@@ -28,6 +28,11 @@ class WsdlDownloader
     const XML_MIN_LENGTH = 25;
 
     /**
+     *  Expected HTTP status code when downloading wsdls.
+     */
+    const HTTP_OK = 200;
+
+    /**
      * Cache enabled.
      *
      * @var bool
@@ -98,9 +103,9 @@ class WsdlDownloader
             if (!$this->cacheEnabled || !file_exists($cacheFilePath) || (filemtime($cacheFilePath) + $this->cacheTtl) < time()) {
                 if ($isRemoteFile) {
                     // execute request
-                    $responseSuccessfull = $this->curl->exec($wsdl);
+                    $this->curl->exec($wsdl);
                     // get content
-                    if ($responseSuccessfull) {
+                    if (static::HTTP_OK === $this->curl->getResponseStatusCode()) {
                         $response = $this->curl->getResponseBody();
                         if (empty($response)) {
                             throw new \ErrorException("SOAP-ERROR: Parsing WSDL: Got empty wsdl from '" . $wsdl ."'");
@@ -112,7 +117,7 @@ class WsdlDownloader
                             file_put_contents($cacheFilePath, $response);
                         }
                     } else {
-                        throw new \ErrorException("SOAP-ERROR: Parsing WSDL: Couldn't load from '" . $wsdl ."'");
+                        throw new \ErrorException("SOAP-ERROR: Parsing WSDL: Unexpected response code received from '" . $wsdl ."', response code: " . $this->curl->getResponseStatusCode());
                     }
                 } elseif (file_exists($wsdl)) {
                     $response = file_get_contents($wsdl);


### PR DESCRIPTION
New feature: Enforce that the response code is 200 when downloading the WSDL, to prevent parsing an access denied or a redirect as the WSDL.