### PR TITLE
Update dependencies and fix tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,8 @@ php:
   - 8.1.0
 
 env:
-  - SYMFONY_VERSION=2.7.*
-  - SYMFONY_VERSION=2.8.*
-  - SYMFONY_VERSION=3.4.*
+  - SYMFONY_VERSION=5.4.*
+  - SYMFONY_VERSION=6.0.*
 
 before_script:
   - phpenv config-add myphp.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,17 @@
 language: php
+os:
+  - linux
+dist: bionic
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
   - 7.4
+  - 8.0
+  - 8.1.0
 
 env:
   - SYMFONY_VERSION=2.7.*
   - SYMFONY_VERSION=2.8.*
   - SYMFONY_VERSION=3.4.*
-
-matrix:
-  allow_failures:
-    - php: 5.6
-    - php: 7.1
 
 before_script:
   - phpenv config-add myphp.ini
@@ -27,7 +22,7 @@ before_script:
   - ./src/BeSimple/SoapClient/Tests/bin/axis.sh
 
 script:
-  - bin/simple-phpunit --coverage-text --debug
+  - SYMFONY_DEPRECATIONS_HELPER="max[indirect]=6" bin/simple-phpunit --coverage-text
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ env:
   - SYMFONY_VERSION=5.4.*
   - SYMFONY_VERSION=6.0.*
 
+jobs:
+  exclude:
+    - php: 7.4
+      env: SYMFONY_VERSION=6.0.*
+
 before_script:
   - phpenv config-add myphp.ini
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,9 @@
         "ext-soap": "*",
         "ext-curl": "*",
         "ass/xmlsecurity": "~1.0",
-        "symfony/framework-bundle": "~2.6 || ~3.4",
-        "symfony/twig-bundle": "~2.6 || ~3.4",
+        "symfony/error-handler": "^5.4.3 || ^6.0.3",
+        "symfony/framework-bundle": "^5.4.4 || ^6.0.4",
+        "laminas/laminas-mail": "2.*",
         "laminas/laminas-mime": "2.*",
         "laminas/laminas-serializer": "^2.12"
     },
@@ -38,8 +39,8 @@
     },
     "require-dev": {
         "mikey179/vfsstream": "~1.0",
-        "symfony/filesystem": "~2.3",
-        "symfony/process": "~2.3",
+        "symfony/filesystem": "^5.4.3 || ^6.0.3",
+        "symfony/process": "^5.4.3 || ^6.0.3",
         "symfony/phpunit-bridge": "*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
         "symfony/framework-bundle": "~2.6 || ~3.4",
         "symfony/twig-bundle": "~2.6 || ~3.4",
         "laminas/laminas-mime": "2.*",
-        "laminas/laminas-serializer": "^2.12",
-        "laminas/laminas-servicemanager": "^3.10.0"
+        "laminas/laminas-serializer": "^2.12"
     },
     "replace": {
         "besimple/soap-bundle": "self.version",

--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,15 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=7.4.0",
         "ext-soap": "*",
         "ext-curl": "*",
         "ass/xmlsecurity": "~1.0",
         "symfony/framework-bundle": "~2.6 || ~3.4",
         "symfony/twig-bundle": "~2.6 || ~3.4",
-        "zendframework/zend-mime": "2.*",
-        "zendframework/zend-serializer": "^2.9",
-        "zendframework/zend-servicemanager": "^3.3"
+        "laminas/laminas-mime": "2.*",
+        "laminas/laminas-serializer": "^2.12",
+        "laminas/laminas-servicemanager": "^3.10.0"
     },
     "replace": {
         "besimple/soap-bundle": "self.version",
@@ -52,6 +52,9 @@
         }
     },
     "config": {
+        "platform": {
+            "php": "7.4.0"
+        },
         "bin-dir": "bin"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -52,9 +52,6 @@
         }
     },
     "config": {
-        "platform": {
-            "php": "7.4.0"
-        },
         "bin-dir": "bin"
     }
 }

--- a/src/BeSimple/SoapBundle/Soap/SoapRequest.php
+++ b/src/BeSimple/SoapBundle/Soap/SoapRequest.php
@@ -11,8 +11,8 @@
 namespace BeSimple\SoapBundle\Soap;
 
 use BeSimple\SoapBundle\Util\Collection;
+use Laminas\Mime\Message;
 use Symfony\Component\HttpFoundation\Request;
-use Zend\Mime\Message;
 
 /**
  * SoapRequest.

--- a/src/BeSimple/SoapBundle/Tests/Soap/SoapRequestTest.php
+++ b/src/BeSimple/SoapBundle/Tests/Soap/SoapRequestTest.php
@@ -23,8 +23,6 @@ class SoapRequestTest extends \PHPUnit\Framework\TestCase
 {
     public function testMtomMessage()
     {
-        $this->markTestSkipped('Skip because I\'m not sure that SoapRequest is used in a HTTP Request process.');
-
         $content = $this->loadRequestContentFixture('mtom/simple.txt');
 
         $request = new SoapRequest(array(), array(), array(), array(), array(), array(), $content);

--- a/src/BeSimple/SoapBundle/Util/Collection.php
+++ b/src/BeSimple/SoapBundle/Util/Collection.php
@@ -53,12 +53,12 @@ class Collection implements \IteratorAggregate, \Countable
         $this->elements = array();
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->elements);
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->elements);
     }

--- a/src/BeSimple/SoapBundle/WebServiceContext.php
+++ b/src/BeSimple/SoapBundle/WebServiceContext.php
@@ -15,9 +15,9 @@ use BeSimple\SoapBundle\ServiceBinding\ServiceBinder;
 use BeSimple\SoapCommon\Converter\TypeConverterCollection;
 use BeSimple\SoapWsdl\Dumper\Dumper;
 use BeSimple\SoapServer\SoapServerBuilder;
+use Laminas\Serializer\Serializer;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\Loader\LoaderInterface;
-use Zend\Serializer\Serializer;
 
 /**
  * WebServiceContext.

--- a/src/BeSimple/SoapClient/SoapClient.php
+++ b/src/BeSimple/SoapClient/SoapClient.php
@@ -238,7 +238,7 @@ class SoapClient extends \SoapClient
      *
      * @return string
      */
-    public function __doRequest($request, $location, $action, $version, $oneWay = 0)
+    public function __doRequest($request, $location, $action, $version, $oneWay = 0): ?string
     {
         // wrap request data in SoapRequest object
         $soapRequest = SoapRequest::create($request, $location, $action, $version);
@@ -307,7 +307,7 @@ class SoapClient extends \SoapClient
      *
      * @return string
      */
-    public function __getLastRequestHeaders()
+    public function __getLastRequestHeaders(): ?string
     {
         return $this->lastRequestHeaders;
     }
@@ -327,7 +327,7 @@ class SoapClient extends \SoapClient
      *
      * @return string
      */
-    public function __getLastRequest()
+    public function __getLastRequest(): ?string
     {
         return $this->lastRequest;
     }
@@ -347,7 +347,7 @@ class SoapClient extends \SoapClient
      *
      * @return string
      */
-    public function __getLastResponseHeaders()
+    public function __getLastResponseHeaders(): ?string
     {
         return $this->lastResponseHeaders;
     }
@@ -357,7 +357,7 @@ class SoapClient extends \SoapClient
      *
      * @return string
      */
-    public function __getLastResponse()
+    public function __getLastResponse(): ?string
     {
         return $this->lastResponse;
     }

--- a/src/BeSimple/SoapClient/Tests/AbstractWebserverTest.php
+++ b/src/BeSimple/SoapClient/Tests/AbstractWebserverTest.php
@@ -13,7 +13,7 @@
 namespace BeSimple\SoapClient\Tests;
 
 use Symfony\Component\Process\PhpExecutableFinder;
-use Symfony\Component\Process\ProcessBuilder;
+use Symfony\Component\Process\Process;
 
 /**
  * @author francis.besset@gmail.com <francis.besset@gmail.com>
@@ -28,19 +28,14 @@ abstract class AbstractWebServerTest extends \PHPUnit\Framework\TestCase
 
     public static function setUpBeforeClass(): void
     {
-        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
-            self::markTestSkipped('PHP Webserver is available from PHP 5.4');
-        }
-
         $phpFinder = new PhpExecutableFinder();
-        self::$webserver = ProcessBuilder::create(array(
-            'exec', // used exec binary (https://github.com/symfony/symfony/issues/5759)
+        self::$webserver = new Process(array(
             $phpFinder->find(),
             '-S',
             sprintf('localhost:%d', WEBSERVER_PORT),
             '-t',
             __DIR__.DIRECTORY_SEPARATOR.'Fixtures',
-        ))->getProcess();
+        ));
 
         self::$webserver->start();
         usleep(200000);

--- a/src/BeSimple/SoapClient/Tests/AbstractWebserverTest.php
+++ b/src/BeSimple/SoapClient/Tests/AbstractWebserverTest.php
@@ -20,17 +20,13 @@ use Symfony\Component\Process\ProcessBuilder;
  */
 abstract class AbstractWebServerTest extends \PHPUnit\Framework\TestCase
 {
-    // when using the SetUpTearDownTrait, methods like doSetup() can
-    // be defined with and without the 'void' return type, as you wish
-    use \Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
-
     /**
      * @var ProcessBuilder
      */
     static protected $webserver;
-    static protected $websererPortLength;
+    static protected $webserverPortLength;
 
-    public static function doSetUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (version_compare(PHP_VERSION, '5.4.0', '<')) {
             self::markTestSkipped('PHP Webserver is available from PHP 5.4');
@@ -49,10 +45,10 @@ abstract class AbstractWebServerTest extends \PHPUnit\Framework\TestCase
         self::$webserver->start();
         usleep(200000);
 
-        self::$websererPortLength = strlen(WEBSERVER_PORT);
+        self::$webserverPortLength = strlen(WEBSERVER_PORT);
     }
 
-    public static function doTearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         self::$webserver->stop(0);
         usleep(100000);

--- a/src/BeSimple/SoapClient/Tests/AxisInterop/TestCase.php
+++ b/src/BeSimple/SoapClient/Tests/AxisInterop/TestCase.php
@@ -4,11 +4,7 @@ namespace BeSimple\SoapClient\Tests\AxisInterop;
 
 class TestCase extends \PHPUnit\Framework\TestCase
 {
-    // when using the SetUpTearDownTrait, methods like doSetup() can
-    // be defined with and without the 'void' return type, as you wish
-    use \Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
-
-    protected function doSetUp()
+    protected function setUp(): void
     {
         $ch = curl_init('http://localhost:8080/');
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);

--- a/src/BeSimple/SoapClient/Tests/CurlTest.php
+++ b/src/BeSimple/SoapClient/Tests/CurlTest.php
@@ -37,13 +37,13 @@ class CurlTest extends AbstractWebserverTest
         ));
 
         $curl->exec('http://unknown/curl.txt');
-        $this->assertRegExp('/^Could not connect to host.*$/', $curl->getErrorMessage());
+        $this->assertMatchesRegularExpression('/^Could not connect to host.*$/', $curl->getErrorMessage());
 
         $curl->exec(sprintf('xyz://localhost:%d/@404.txt', WEBSERVER_PORT));
-        $this->assertRegExp('/^Unknown protocol. Only http and https are allowed.*$/', $curl->getErrorMessage());
+        $this->assertMatchesRegularExpression('/^Unknown protocol. Only http and https are allowed.*$/', $curl->getErrorMessage());
 
         $curl->exec('');
-        $this->assertRegExp('/^Unable to parse URL.*$/', $curl->getErrorMessage());
+        $this->assertMatchesRegularExpression('/^Unable to parse URL.*$/', $curl->getErrorMessage());
     }
 
     public function testGetRequestHeaders()

--- a/src/BeSimple/SoapClient/Tests/ServerInterop/TestCase.php
+++ b/src/BeSimple/SoapClient/Tests/ServerInterop/TestCase.php
@@ -4,18 +4,8 @@ namespace BeSimple\SoapClient\Tests\ServerInterop;
 
 class TestCase extends \PHPUnit\Framework\TestCase
 {
-    // when using the SetUpTearDownTrait, methods like doSetup() can
-    // be defined with and without the 'void' return type, as you wish
-    use \Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
-
-    protected function doSetUp()
+    protected function setUp(): void
     {
-        if (version_compare(PHP_VERSION, '5.3.0', '=')) {
-            $this->markTestSkipped(
-                'The PHP cli webserver is not available with PHP 5.3.'
-            );
-        }
-
         $ch = curl_init('http://localhost:8081/');
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
         curl_setopt($ch, CURLOPT_HEADER, true);

--- a/src/BeSimple/SoapClient/Tests/SoapClientTest.php
+++ b/src/BeSimple/SoapClient/Tests/SoapClientTest.php
@@ -50,7 +50,7 @@ class SoapClientTest extends \PHPUnit\Framework\TestCase
         }
 
         $this->assertInstanceOf('SoapFault', $soapFault, 'Invalid type of exception');
-        $this->assertRegExp('/SOAP-ERROR: Parsing WSDL: .*/', $soapFault->getMessage(), 'Invalid or incorrect exception message');
+        $this->assertMatchesRegularExpression('/SOAP-ERROR: Parsing WSDL: .*/', $soapFault->getMessage(), 'Invalid or incorrect exception message');
         $this->assertStringContainsString('WSDL', $soapFault->faultcode, 'Invalid type of faultcode');
     }
 

--- a/src/BeSimple/SoapClient/Tests/WsdlDownloaderTest.php
+++ b/src/BeSimple/SoapClient/Tests/WsdlDownloaderTest.php
@@ -53,7 +53,7 @@ class WsdlDownloaderTest extends AbstractWebserverTest
 
         //Test that the Cache filename is valid
         $regexp = '#'.sprintf($regexp, $cacheDirForRegExp).'#';
-        $this->assertRegExp($regexp, $cacheFileName);
+        $this->assertMatchesRegularExpression($regexp, $cacheFileName);
 
     }
 
@@ -133,7 +133,7 @@ class WsdlDownloaderTest extends AbstractWebserverTest
         $m->invoke($wsdlDownloader, file_get_contents($source), $cacheFile, $remoteParentUrl);
         $this->assertCount($nbDownloads, $wsdlCacheDir->getChildren());
 
-        $this->assertRegExp('#'.sprintf($regexp, $cacheDirForRegExp).'#', file_get_contents($cacheFile));
+        $this->assertMatchesRegularExpression('#'.sprintf($regexp, $cacheDirForRegExp).'#', file_get_contents($cacheFile));
     }
 
     public function provideResolveWsdlIncludes()
@@ -200,7 +200,7 @@ class WsdlDownloaderTest extends AbstractWebserverTest
         $m->invoke($wsdlDownloader, file_get_contents($source), $cacheFile, $remoteParentUrl);
         $this->assertCount($nbDownloads, $wsdlCacheDir->getChildren());
 
-        $this->assertRegExp('#'.sprintf($regexp, $cacheDirForRegExp).'#', file_get_contents($cacheFile));
+        $this->assertMatchesRegularExpression('#'.sprintf($regexp, $cacheDirForRegExp).'#', file_get_contents($cacheFile));
     }
 
     public function provideResolveXsdIncludes()
@@ -326,7 +326,7 @@ class WsdlDownloaderTest extends AbstractWebserverTest
 
         $result = $wsdlDownloader->download('http://somefake.url/wsdl');
 
-        $this->assertRegExp('/.*wsdl_[a-f0-9]{32}\.cache/', $result);
+        $this->assertMatchesRegularExpression('/.*wsdl_[a-f0-9]{32}\.cache/', $result);
     }
 
     public static function setUpBeforeClass(): void

--- a/src/BeSimple/SoapClient/Tests/WsdlDownloaderTest.php
+++ b/src/BeSimple/SoapClient/Tests/WsdlDownloaderTest.php
@@ -25,10 +25,6 @@ use org\bovigo\vfs\vfsStreamWrapper;
  */
 class WsdlDownloaderTest extends AbstractWebserverTest
 {
-    // when using the SetUpTearDownTrait, methods like doSetup() can
-    // be defined with and without the 'void' return type, as you wish
-    use \Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
-
     protected static $filesystem;
 
     protected static $fixturesPath;
@@ -333,7 +329,7 @@ class WsdlDownloaderTest extends AbstractWebserverTest
         $this->assertRegExp('/.*wsdl_[a-f0-9]{32}\.cache/', $result);
     }
 
-    public static function doSetUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -349,7 +345,7 @@ class WsdlDownloaderTest extends AbstractWebserverTest
         }
     }
 
-    public static function doTearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         parent::tearDownAfterClass();
 

--- a/src/BeSimple/SoapCommon/FilterHelper.php
+++ b/src/BeSimple/SoapCommon/FilterHelper.php
@@ -134,7 +134,7 @@ class FilterHelper
      *
      * @return \DOMElement
      */
-    public function createElement($namespaceURI, $name, $value = null)
+    public function createElement($namespaceURI, $name, $value = '')
     {
         $prefix = $this->namespaces[$namespaceURI];
 

--- a/src/BeSimple/SoapCommon/Mime/PartHeader.php
+++ b/src/BeSimple/SoapCommon/Mime/PartHeader.php
@@ -86,7 +86,7 @@ abstract class PartHeader
      */
     protected function generateHeaders()
     {
-        $charset = strtolower($this->getHeader('Content-Type', 'charset'));
+        $charset = strtolower($this->getHeader('Content-Type', 'charset') ?? '');
         $preferences = array(
             'scheme' => 'Q',
             'input-charset' => 'utf-8',

--- a/src/BeSimple/SoapCommon/Tests/CacheTest.php
+++ b/src/BeSimple/SoapCommon/Tests/CacheTest.php
@@ -18,10 +18,6 @@ use org\bovigo\vfs\vfsStreamWrapper;
 
 class SoapRequestTest extends \PHPUnit\Framework\TestCase
 {
-    // when using the SetUpTearDownTrait, methods like doSetup() can
-    // be defined with and without the 'void' return type, as you wish
-    use \Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
-
     public function testSetEnabled()
     {
         Cache::setEnabled(Cache::ENABLED);
@@ -87,7 +83,7 @@ class SoapRequestTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(1, Cache::getLimit());
     }
 
-    public function doSetUp()
+    public function setUp(): void
     {
         ini_restore('soap.wsdl_cache_enabled');
         ini_restore('soap.wsdl_cache');

--- a/src/BeSimple/SoapCommon/Tests/Mime/MultiPartTest.php
+++ b/src/BeSimple/SoapCommon/Tests/Mime/MultiPartTest.php
@@ -26,7 +26,7 @@ class MultiPartTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('multipart/related', $mp->getHeader('Content-Type'));
         $this->assertEquals('text/xml', $mp->getHeader('Content-Type', 'type'));
         $this->assertEquals('utf-8', $mp->getHeader('Content-Type', 'charset'));
-        $this->assertRegExp('~urn:uuid:.*~', $mp->getHeader('Content-Type', 'boundary'));
+        $this->assertMatchesRegularExpression('~urn:uuid:.*~', $mp->getHeader('Content-Type', 'boundary'));
     }
 
     public function testGetMimeMessage()

--- a/src/BeSimple/SoapCommon/Tests/Mime/PartTest.php
+++ b/src/BeSimple/SoapCommon/Tests/Mime/PartTest.php
@@ -36,7 +36,7 @@ class PartTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('application/octet-stream', $p->getHeader('Content-Type'));
         $this->assertEquals('utf-8', $p->getHeader('Content-Type', 'charset'));
         $this->assertEquals(Part::ENCODING_BINARY, $p->getHeader('Content-Transfer-Encoding'));
-        $this->assertRegExp('~<urn:uuid:.*>~', $p->getHeader('Content-ID'));
+        $this->assertMatchesRegularExpression('~<urn:uuid:.*>~', $p->getHeader('Content-ID'));
     }
 
     public function testSetContent()

--- a/src/BeSimple/SoapServer/SoapServer.php
+++ b/src/BeSimple/SoapServer/SoapServer.php
@@ -64,7 +64,7 @@ class SoapServer extends \SoapServer
      *
      * @param string $request Request string
      */
-    public function handle($request = null)
+    public function handle($request = null): void
     {
         // wrap request data in SoapRequest object
         $soapRequest = SoapRequest::create($request, $this->soapVersion);


### PR DESCRIPTION
- These changes add support for PHP 8.0 and 8.1. Minimum PHP version is raised to 7.4.
- Switches from zend to laminas for up-to-date dependencies that support recent PHP versions.
- Removes unused dependencies (twig, service-manager).
- Makes curl tests more robust.
- Resurrects the `testMtomMessage` test and add laminas-mail dependency that laminas-mime needs for it to work.
- Adds return types and fixes other deprecation issues.